### PR TITLE
dask-expr 1.1.13

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/dask-core-feedstock/pr35/433a97b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/dask-core-feedstock/pr35/433a97b

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,9 @@ test:
   commands:
     - pip check
 
+#Note: The build and dependency order for dask-distributed packages are as follows.
+#      dask-core ---> dask-expr --->distributed --->dask
+
 about:
   home: https://github.com/dask/dask-expr
   summary: High Level Expressions for Dask

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask-expr" %}
-{% set version = "1.1.0" %}
+{% set version = "1.1.13" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/dask_expr-{{ version }}.tar.gz
-  sha256: cd0e0ad4d65229a4fd22a231fa9c7e632cef09c5b6ab7259bdaaaadd20179cdb
+  sha256: 7e00b2c6538e6c633e22db262abfe3aeb6dc65c1de4a8eadcb2bbf44ad8729da
 
 build:
   number: 0
-  skip: True  # [py<39]
+  skip: True  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
@@ -24,8 +24,8 @@ requirements:
     - wheel
   run:
     - python
-    - dask-core ==2024.5.0
-    - pyarrow >=7.0.0
+    - dask-core ==2024.8.2
+    - pyarrow >=14.0.1
     - pandas >=2
 
 test:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5627](https://anaconda.atlassian.net/browse/PKG-5627) 
- [Upstream repository](https://github.com/dask/dask-expr/tree/v1.1.13)
- Requirements: https://github.com/dask/dask-expr/blob/v1.1.13/pyproject.toml

### Explanation of changes:

- Skip py<310
- Update runtime pinnings

### Notes:

- It's a dependency for https://github.com/AnacondaRecipes/dask-feedstock/pull/37

[PKG-5627]: https://anaconda.atlassian.net/browse/PKG-5627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ