### PR TITLE
dask-expr 1.1.21

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/partd-feedstock/pr5/f58f9d8
-  - https://staging.continuum.io/prefect/fs/dask-core-feedstock/pr36/bcd17e0
-  - https://staging.continuum.io/prefect/fs/toolz-feedstock/pr3/9c8f0c4

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,3 +4,4 @@ build_env_vars:
 channels:
   - https://staging.continuum.io/prefect/fs/partd-feedstock/pr5/f58f9d8
   - https://staging.continuum.io/prefect/fs/dask-core-feedstock/pr36/bcd17e0
+  - https://staging.continuum.io/prefect/fs/toolz-feedstock/pr3/9c8f0c4

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/partd-feedstock/pr5/f58f9d8
+  - https://staging.continuum.io/prefect/fs/dask-core-feedstock/pr36/bcd17e0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
 
 test:
   imports:
-    - dask-expr
+    - dask_expr
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask-expr" %}
-{% set version = "1.1.21" %}
+{% set version = "1.1.20" %}
 
 package:
   name: {{ name|lower }}
@@ -20,11 +20,11 @@ requirements:
     - pip
     - setuptools
     - tomli
-    - versioneer
+    - versioneer ==0.28
     - wheel
   run:
     - python
-    - dask-core ==2024.12.1
+    - dask-core ==2024.12.0
     - pyarrow >=14.0.1
     - pandas >=2
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,11 +20,11 @@ requirements:
     - pip
     - setuptools
     - tomli
-    - versioneer =0.28
+    - versioneer ==0.28
     - wheel
   run:
     - python
-    - dask-core ==2024.8.2
+    - dask-core ==2024.12.1
     - pyarrow >=14.0.1
     - pandas >=2
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
 
 test:
   imports:
-    - dask_expr
+    - dask-expr
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask-expr" %}
-{% set version = "1.1.20" %}
+{% set version = "1.1.21" %}
 
 package:
   name: {{ name|lower }}
@@ -24,7 +24,7 @@ requirements:
     - wheel
   run:
     - python
-    - dask-core ==2024.12.0
+    - dask-core ==2024.12.1
     - pyarrow >=14.0.1
     - pandas >=2
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - pip
     - setuptools
     - tomli
-    - versioneer ==0.28
+    - versioneer
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask-expr" %}
-{% set version = "1.1.13" %}
+{% set version = "1.1.21" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/dask_expr-{{ version }}.tar.gz
-  sha256: 7e00b2c6538e6c633e22db262abfe3aeb6dc65c1de4a8eadcb2bbf44ad8729da
+  sha256: eb45de8e6fea1ce2608a431b4e03a484592defb1796665530c91386ffac581d3
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6587](https://anaconda.atlassian.net/browse/PKG-6587)
- [Upstream repository](https://github.com/dask/dask-expr/tree/v1.1.21)


### Explanation of changes:

- Update version and dependencies
- Build for python 3.13


[PKG-6587]: https://anaconda.atlassian.net/browse/PKG-6587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ