### PR TITLE
dask-expr V2.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,14 +19,10 @@ requirements:
     - python
     - pip
     - setuptools
-    - tomli
-    - versioneer
     - wheel
   run:
     - python
-    - dask-core ==2024.12.1
-    - pyarrow >=14.0.1
-    - pandas >=2
+    - dask-core >=2025.1.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask-expr" %}
-{% set version = "1.1.21" %}
+{% set version = "2.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/dask_expr-{{ version }}.tar.gz
-  sha256: eb45de8e6fea1ce2608a431b4e03a484592defb1796665530c91386ffac581d3
+  sha256: e6d5a7bdff927aa4a1754a76cad79c5925254c525f568038df7832fcd558fc11
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7389](https://anaconda.atlassian.net/browse/PKG-7389)
- [Upstream repository](https://github.com/dask/dask-expr/tree/v2.0.0)

### Explanation of changes:

- Update version number and sha256
- Update build and runtime dependencies


[PKG-7389]: https://anaconda.atlassian.net/browse/PKG-7389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ